### PR TITLE
Feature/checklist

### DIFF
--- a/working-on/.gitignore
+++ b/working-on/.gitignore
@@ -1,0 +1,58 @@
+### macOS ###
+# General
+.DS_Store
+.AppleDouble
+.LSOverride
+
+# Icon must end with two \r
+Icon
+
+# Thumbnails
+._*
+
+# Files that might appear in the root of a volume
+.DocumentRevisions-V100
+.fseventsd
+.Spotlight-V100
+.TemporaryItems
+.Trashes
+.VolumeIcon.icns
+.com.apple.timemachine.donotpresent
+
+# Directories potentially created on remote AFP share
+.AppleDB
+.AppleDesktop
+Network Trash Folder
+Temporary Items
+.apdisk
+
+### Windows ###
+# Windows thumbnail cache files
+Thumbs.db
+Thumbs.db:encryptable
+ehthumbs.db
+ehthumbs_vista.db
+
+# Dump file
+*.stackdump
+
+# Folder config file
+[Dd]esktop.ini
+
+# Recycle Bin used on file shares
+$RECYCLE.BIN/
+
+# Windows Installer files
+*.cab
+*.msi
+*.msix
+*.msm
+*.msp
+
+# Windows shortcuts
+*.lnk
+
+### Other ###
+# Temporary folders
+tmp/
+temp/

--- a/working-on/checklist/checkbox.scss
+++ b/working-on/checklist/checkbox.scss
@@ -1,0 +1,126 @@
+.provisional {
+  [role="checkbox"] {
+    /* (0,2,0) */
+    cursor: default;
+    display: inline-block;
+    padding-left: 30px;
+    position: relative;
+
+    &::before, &::after {
+      /* (0,2,1) */
+      left: 0;
+      position: absolute;
+      top: 0;
+      transform: translate(-50%, -50%);
+    }
+
+    &::before {
+      /* (0,2,1) */
+      border: 2px solid hsl(0, 0%, 15%);
+      content: "";
+      height: 36px;
+      width: 36px;
+    }
+
+    &::after {
+      /* (0,2,1) */
+      content: none;
+    }
+
+    &:focus {
+      /* (0,3,0) */
+      outline: none;
+    }
+
+    &:checked::after {
+      /* (0,3,1) */
+      content: "";
+    }
+
+    &:active::before,
+    &[aria-checked="false"]:hover::before {
+      /* (0,3,1) */
+      background-image: linear-gradient(to bottom, hsl(300, 3%, 73%), hsl(300, 3%, 93%) 30%);
+    }
+
+    &[aria-checked="true"]::after {
+      /* (0,3,1) */
+      border-color: #333;
+      border-style: solid;
+      border-width: 0 5px 5px 0;
+      content: "";
+      display: inline-block;
+      height: 26px;
+      left: -4px;
+      top: 1px;
+      width: 13px;
+      -webkit-transform: rotate(45deg);
+      -ms-transform: rotate(45deg);
+      transform: rotate(45deg);
+    }
+
+    &:focus::before {
+      /* (0,3,1) */
+      box-shadow: 0 0 3pt 2pt rgb(59, 153, 252);
+      box-sizing: content-box;
+      height: 16px;
+      width: 16px;
+    }
+  }
+
+  ul.wb-chcklst {
+    /* (0,2,1) */
+    font-size: 20px;
+    margin-left: 0;
+    padding-top: 6px;
+  }
+
+  .lst-none ul li {
+    /* (0,2,2) */
+    list-style-type: disc;
+  }
+
+  ul.wb-chcklst.sm-chcklst {
+    /* (0,3,1) */
+    font-size: 17px;
+  }
+
+  .sm-chcklst [role="checkbox"]::before {
+    /* (0,3,1) */
+    height: 24px;
+    left: 10px;
+    top: 11px;
+    width: 24px;
+  }
+
+  ul.wb-chcklst {
+    &.sm-chcklst > li {
+      /* (0,3,2) */
+      line-height: 23px;
+      margin-bottom: 25px;
+      margin-top: 10px;
+    }
+
+    [role="checkbox"][aria-checked="true"] {
+      &::before {
+        /* (0,4,2) */
+        background-color: #318000;
+      }
+
+      &::after {
+        /* (0,4,2) */
+        border-color: white;
+        border-width: 0 4px 4px 0;
+      }
+    }
+  }
+
+  .sm-chcklst [role="checkbox"][aria-checked="true"]::after {
+    /* (0,4,1) */
+    border-width: 0 4px 4px 0;
+    height: 16px;
+    left: 6px;
+    top: 1px;
+    width: 9px;
+  }
+}

--- a/working-on/checklist/checklist.css
+++ b/working-on/checklist/checklist.css
@@ -1,107 +1,153 @@
+/********
+ ********
+ ** Heydron Pickering example
+ ** October 15, 2014
+ ** Replacing radio buttons without replacing radio buttons
+ ** https://www.sitepoint.com/replacing-radio-buttons-without-replacing-radio-buttons/
+ ********
+ ********/
+
+ /* One input per line */
+.provisional label { /* (0,1,1) */
+  cursor: pointer;
+  display: block;
+  font-size: 20px;
+  line-height: 2;
+}
+
 .provisional [role="checkbox"] { /* (0,2,0) */
-  cursor: default;
+  cursor: pointer;
   display: inline-block;
-  padding-left: 30px;
+  padding-left: 15px;
   position: relative;
+}
+
+.provisional fieldset.chkbxrdio-grp legend { /* (0,2,2) */
+  float: none;
+  font-size: 22px;
+  margin-bottom: 15px;
+  margin-top: 0;
+}
+
+.provisional [type="radio"],
+.provisional [type="checkbox"] { /* (0,2,0) */
+  border: 0; 
+  clip: rect(0 0 0 0); 
+  height: 1px;
+  margin: -1px; 
+  padding: 0; 
+  position: absolute; 
+  overflow: hidden; 
+  width: 1px;
+}
+
+.provisional [type="radio"] + span,
+.provisional [type="checkbox"] + span { /* (0,2,1) */
+  display: block;
+  margin-left: 36px;
 }
 
 .provisional [role="checkbox"]::before,
 .provisional [role="checkbox"]::after { /* (0,2,1) */
+  content: "";
   left: 0;
   position: absolute;
   top: 0;
-  transform: translate(-50%, -50%);
+  transform: translate(-100%, 0%);
 }
 
+.provisional .wb-checklist.wb-checklist-sm { /* (0,3,0) */
+  font-size: 17px;
+}
+
+/* the basic, unchecked style */
 .provisional [role="checkbox"]::before { /* (0,2,1) */
-  border: 2px solid hsl(0, 0%, 15%);
-  content: "";
+  border: 4px solid #fff;
+  box-shadow: 0 0 0 2px #000;
+  display: inline-block;
   height: 36px;
   width: 36px;
 }
-.provisional [role="checkbox"]::after { /* (0,2,1) */
-  content: none;
+
+.provisional .wb-checklist-sm [role="checkbox"]::before { /* (0,3,1) */
+  border-width: 3px;
+  height: 24px;
+  transform: translate(-100%, 20%);
+  width: 24px;
 }
 
-.provisional ul.wb-chcklst { /* (0,2,1) */
-  font-size: 20px;
-  margin-left: 0;
-  padding-top: 6px;
+.provisional [type="radio"] + span::before,
+.provisional [type="checkbox"] + span::before { /* (0,2,2) */
+  border: 4px solid #fff;
+  box-shadow: 0 0 0 2px #000;
+  content: "";
+  display: inline-block;
+  height: 36px;
+  left: 0;
+  position: absolute;
+  top: 0;
+  width: 36px;
 }
 
-.provisional .lst-none ul li { /* (0,2,2) */
-  list-style-type: disc;
+.provisional [type="radio"] + span::before { /* (0,2,2) */
+  border-radius: 50%;
 }
 
+/* hover styling */
+.provisional [type="radio"]:hover + span::before,
+.provisional [type="checkbox"]:hover + span::before, /* (0,3,2) */
+.provisional [role="checkbox"][aria-checked="false"]:hover::before { /* (0,3,1) */
+  background-image: linear-gradient(to bottom, hsl(10, 0%, 90%), hsl(10, 0%, 100%) 50%);
+}
+
+/* focus styling */
 .provisional [role="checkbox"]:focus { /* (0,3,0) */
   outline: none;
 }
-.provisional [role="checkbox"]:hover { /* (0,3,0) */
-  cursor: pointer;
-}
-.provisional [role="checkbox"]:checked::after { /* (0,3,1) */
-  content: "";
+
+.provisional [type="radio"]:focus + span::before,
+.provisional [type="checkbox"]:focus + span::before,
+.provisional [role="checkbox"]:focus::before { /* (0,3,2) */
+  box-shadow: 0 0 0 2px #000, 0 0 8px 4px rgb(59, 153, 252);
 }
 
-.provisional [role="checkbox"]:active::before,
-.provisional [role="checkbox"][aria-checked="false"]:hover::before { /* (0,3,1) */
-  background-image: linear-gradient(to bottom, hsl(300, 3%, 73%), hsl(300, 3%, 93%) 30%);
+/* the checked style using the :checked pseudo class and aria-checked=true attribute */
+.provisional [role="checkbox"][aria-checked="true"]::before { /* (0,3,1) */
+  background-color: #318000;
+  border-width: 2px;
 }
 
 .provisional [role="checkbox"][aria-checked="true"]::after { /* (0,3,1) */
+  border-color: white;
+  border-style: solid;
+  border-width: 0 5px 5px 0;
+  display: inline-block;
+  height: 26px;
+  width: 13px;
+  transform: translate(-185%, 10%) rotate(45deg);
+}
+
+.provisional .wb-checklist-sm [role="checkbox"][aria-checked="true"]::after { /* (0,3,1) */
+  border-width: 0 4px 4px 0;
+  height: 16px;
+  width: 9px;
+  transform: translate(-185%, 40%) rotate(45deg);
+}
+
+.provisional [type="radio"]:checked + span::before { /* (0,3,2) */
+  background: #444;
+}
+
+.provisional [type="checkbox"]:checked + span::after { /* (0,3,2) */
   border-color: #333;
   border-style: solid;
   border-width: 0 5px 5px 0;
   content: "";
   display: inline-block;
   height: 26px;
-  left: -4px;
-  top: 1px;
-  width: 13px;
-  -webkit-transform: rotate(45deg);
-  -ms-transform: rotate(45deg);
+  left: 12px;
+  position: absolute;
+  top: 2px;
   transform: rotate(45deg);
-}
-
-.provisional [role="checkbox"]:focus::before { /* (0,3,1) */
-  box-shadow: 0 0 3pt 2pt rgb(59, 153, 252);
-  box-sizing: content-box;
-  height: 16px;
-  width: 16px;
-}
-
-.provisional ul.wb-chcklst.sm-chcklst { /* (0,3,1) */
-  font-size: 17px;
-}
-
-
-.provisional .sm-chcklst [role="checkbox"]::before { /* (0,3,1) */
-  height: 24px;
-  left: 10px;
-  top: 11px;
-  width: 24px;
-}
-
-.provisional ul.wb-chcklst.sm-chcklst > li { /* (0,3,2) */
-  line-height: 23px;
-  margin-bottom: 25px;
-  margin-top: 10px;
-}
-
-.provisional ul.wb-chcklst [role="checkbox"][aria-checked="true"]::before,
-.provisional ul.wb-chcklst [role="checkbox"][aria-checked="true"]:hover::before { /* (0,4,2) */
-  background-color: #318000;
-}
-
-.provisional ul.wb-chcklst [role="checkbox"][aria-checked="true"]::after { /* (0,4,2) */
-  border-color: white;
-  border-width: 0 4px 4px 0;
-}
-
-.provisional .sm-chcklst [role="checkbox"][aria-checked="true"]::after { /* (0,4,1) */
-  border-width: 0 4px 4px 0;
-  height: 16px;
-  left: 6px;
-  top: 1px;
-  width: 9px;
+  width: 13px;
 }

--- a/working-on/checklist/checklist.css
+++ b/working-on/checklist/checklist.css
@@ -1,0 +1,107 @@
+.provisional [role="checkbox"] { /* (0,2,0) */
+  cursor: default;
+  display: inline-block;
+  padding-left: 30px;
+  position: relative;
+}
+
+.provisional [role="checkbox"]::before,
+.provisional [role="checkbox"]::after { /* (0,2,1) */
+  left: 0;
+  position: absolute;
+  top: 0;
+  transform: translate(-50%, -50%);
+}
+
+.provisional [role="checkbox"]::before { /* (0,2,1) */
+  border: 2px solid hsl(0, 0%, 15%);
+  content: "";
+  height: 36px;
+  width: 36px;
+}
+.provisional [role="checkbox"]::after { /* (0,2,1) */
+  content: none;
+}
+
+.provisional ul.wb-chcklst { /* (0,2,1) */
+  font-size: 20px;
+  margin-left: 0;
+  padding-top: 6px;
+}
+
+.provisional .lst-none ul li { /* (0,2,2) */
+  list-style-type: disc;
+}
+
+.provisional [role="checkbox"]:focus { /* (0,3,0) */
+  outline: none;
+}
+.provisional [role="checkbox"]:hover { /* (0,3,0) */
+  cursor: pointer;
+}
+.provisional [role="checkbox"]:checked::after { /* (0,3,1) */
+  content: "";
+}
+
+.provisional [role="checkbox"]:active::before,
+.provisional [role="checkbox"][aria-checked="false"]:hover::before { /* (0,3,1) */
+  background-image: linear-gradient(to bottom, hsl(300, 3%, 73%), hsl(300, 3%, 93%) 30%);
+}
+
+.provisional [role="checkbox"][aria-checked="true"]::after { /* (0,3,1) */
+  border-color: #333;
+  border-style: solid;
+  border-width: 0 5px 5px 0;
+  content: "";
+  display: inline-block;
+  height: 26px;
+  left: -4px;
+  top: 1px;
+  width: 13px;
+  -webkit-transform: rotate(45deg);
+  -ms-transform: rotate(45deg);
+  transform: rotate(45deg);
+}
+
+.provisional [role="checkbox"]:focus::before { /* (0,3,1) */
+  box-shadow: 0 0 3pt 2pt rgb(59, 153, 252);
+  box-sizing: content-box;
+  height: 16px;
+  width: 16px;
+}
+
+.provisional ul.wb-chcklst.sm-chcklst { /* (0,3,1) */
+  font-size: 17px;
+}
+
+
+.provisional .sm-chcklst [role="checkbox"]::before { /* (0,3,1) */
+  height: 24px;
+  left: 10px;
+  top: 11px;
+  width: 24px;
+}
+
+.provisional ul.wb-chcklst.sm-chcklst > li { /* (0,3,2) */
+  line-height: 23px;
+  margin-bottom: 25px;
+  margin-top: 10px;
+}
+
+.provisional ul.wb-chcklst [role="checkbox"][aria-checked="true"]::before,
+.provisional ul.wb-chcklst [role="checkbox"][aria-checked="true"]:hover::before { /* (0,4,2) */
+  background-color: #318000;
+}
+
+.provisional ul.wb-chcklst [role="checkbox"][aria-checked="true"]::after { /* (0,4,2) */
+  border-color: white;
+  border-width: 0 4px 4px 0;
+}
+
+.provisional .sm-chcklst [role="checkbox"][aria-checked="true"]::after { /* (0,4,1) */
+  border-width: 0 4px 4px 0;
+  height: 16px;
+  left: 6px;
+  top: 1px;
+  width: 9px;
+}

--- a/working-on/checklist/checklist.html
+++ b/working-on/checklist/checklist.html
@@ -5,9 +5,9 @@
 		<!-- Web Experience Toolkit (WET) / Boîte à outils de l'expérience Web (BOEW) wet-boew.github.io/wet-boew/License-en.html / wet-boew.github.io/wet-boew/Licence-fr.html -->
 		<title>Checklist, checboxes and radio button experimentations - Canada.ca</title>
     <meta content="width=device-width,initial-scale=1" name="viewport">
-    <link rel="stylesheet" href="checklist-1.css">
+    <link rel="stylesheet" href="checklist.css">
 		<script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/v4_0_30/cdts/compiled/soyutils.js"></script>
-		<script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/v4_0_30/cdts/compiled/wet-en.js"></script>
+    <script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/v4_0_30/cdts/compiled/wet-en.js"></script>
 		<!-- Write closure template -->
 		<script>
 			document.write(wet.builder.refTop({
@@ -137,7 +137,7 @@
       </section>
       <section role="group" class="provisional">
         <h2 class="wb-inv">Example 4</h2>
-        <fieldset class="chkbxrdio-grp">
+        <fieldset class="chkbxrdio-grp wb-checklist">
           <legend>
             To qualify, you must meet <strong>all</strong> of the following <conditions:small class="text-muted">(checkboxes + implicite label, large box)</conditions:small>
           </legend>
@@ -162,11 +162,11 @@
               </label>
             </li>
           </ul>
-          <div role="checkbox"
-              class="group_checkbox"
-              aria-checked="false"
-              aria-controls="cond1 cond2 cond3 cond4"
-              tabindex="0">
+          <div  role="checkbox"
+                class="group_checkbox"
+                aria-checked="false"
+                wb-data-controls="cond10 cond11 cond2"
+                tabindex="0">
               You are eligible and ready to proceed
           </div>
         </fieldset>
@@ -199,13 +199,6 @@
               </label>
             </li>
           </ul>
-          <div role="checkbox"
-              class="group_checkbox"
-              aria-checked="false"
-              aria-controls="cond1 cond2 cond3 cond4"
-              tabindex="0">
-              You are eligible and ready to proceed
-          </div>
         </fieldset>
       </section>      <div id="def-preFooter"></div>
       <!-- Write closure template -->
@@ -233,5 +226,6 @@
       document.write(wet.builder.refFooter({
       }));
     </script>
+    <script src="wb-checklist.js"></script>
   </body>
 </html>

--- a/working-on/checklist/checklist.html
+++ b/working-on/checklist/checklist.html
@@ -5,7 +5,7 @@
 		<!-- Web Experience Toolkit (WET) / Boîte à outils de l'expérience Web (BOEW) wet-boew.github.io/wet-boew/License-en.html / wet-boew.github.io/wet-boew/Licence-fr.html -->
 		<title>Checklist, checboxes and radio button experimentations - Canada.ca</title>
     <meta content="width=device-width,initial-scale=1" name="viewport">
-    <link rel="stylesheet" href="checklist.css">
+    <link rel="stylesheet" href="checklist-1.css">
 		<script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/v4_0_30/cdts/compiled/soyutils.js"></script>
 		<script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/v4_0_30/cdts/compiled/wet-en.js"></script>
 		<!-- Write closure template -->
@@ -44,13 +44,13 @@
       <h1 property="name">Checklist examples</h1>
       <section role="group" class="provisional">
         <h2 class="wb-inv">Example 1</h2>
-        <p>To qualify, you must meet <strong>all</strong> of the following conditions:</p>
-        <ul class="wb-checklist wb-checklist-sm lst-none lst-spcd">
+        <p>To qualify, you must meet <strong>all</strong> of the following conditions: <small class="text-muted">(checklist, large box)</small></p>
+        <ul class="wb-checklist lst-none lst-spcd">
           <li>
             <div role="checkbox"
                   aria-checked="false"
                   tabindex="0"
-                  id="eligibility1">
+                  id="cond1">
               You have lost or will lose your employment or self-employment income for at least half of the 4-week period for which you are applying
             </div>
           </li>
@@ -58,7 +58,7 @@
             <div role="checkbox"
                   aria-checked="false"
                   tabindex="0"
-                  id="eligibility2">
+                  id="cond2">
               You are a resident of Canada
             </div>
           </li>
@@ -66,7 +66,7 @@
             <div role="checkbox"
                   aria-checked="false"
                   tabindex="0"
-                  id="eligibility3">
+                  id="cond3">
               You are 15 years of age or older when you apply
             </div>
           </li>
@@ -75,41 +75,139 @@
       </section>
       <section role="group" class="provisional">
         <h2 class="wb-inv">Example 2</h2>
+        <p>To qualify, you must meet <strong>all</strong> of the following conditions: <small class="text-muted">(checklist, small box)</small></p>
+        <ul class="wb-checklist wb-checklist-sm lst-none lst-spcd">
+          <li>
+            <div role="checkbox"
+                  aria-checked="false"
+                  tabindex="0"
+                  id="cond4">
+              You have lost or will lose your employment or self-employment income for at least half of the 4-week period for which you are applying
+            </div>
+          </li>
+          <li>
+            <div role="checkbox"
+                  aria-checked="false"
+                  tabindex="0"
+                  id="cond5">
+              You are a resident of Canada
+            </div>
+          </li>
+          <li>
+            <div role="checkbox"
+                  aria-checked="false"
+                  tabindex="0"
+                  id="cond6">
+              You are 15 years of age or older when you apply
+            </div>
+          </li>
+        </ul>
+        <p class="alert alert-success invisible" id="action-msg-all">You are eligible and ready to proceed</p>
+      </section>
+      <section role="group" class="provisional">
+        <h2 class="wb-inv">Example 3</h2>
+        <p>To qualify, you must meet <strong>all</strong> of the following conditions: <small class="text-muted">(checklist + label, small box)</small></p>
+        <ul class="wb-checklist wb-checklist-sm lst-none lst-spcd">
+          <li>
+            <div role="checkbox"
+                  aria-checked="false"
+                  tabindex="0"
+                  id="cond7">
+              You have lost or will lose your employment or self-employment income for at least half of the 4-week period for which you are applying
+            </div>
+          </li>
+          <li>
+            <div role="checkbox"
+                  aria-checked="false"
+                  tabindex="0"
+                  id="cond8">
+              You are a resident of Canada
+            </div>
+          </li>
+          <li>
+            <div role="checkbox"
+                  aria-checked="false"
+                  tabindex="0"
+                  id="cond9">
+              You are 15 years of age or older when you apply
+            </div>
+          </li>
+        </ul>
+        <p class="alert alert-success invisible" id="action-msg-all">You are eligible and ready to proceed</p>
+      </section>
+      <section role="group" class="provisional">
+        <h2 class="wb-inv">Example 4</h2>
         <fieldset class="chkbxrdio-grp">
           <legend>
-            To qualify, you must meet <strong>all</strong> of the following conditions:
+            To qualify, you must meet <strong>all</strong> of the following <conditions:small class="text-muted">(checkboxes + implicite label, large box)</conditions:small>
           </legend>
           <ul class="form-group list-unstyled">
             <li class="checkbox">
               <label>
-                <input type="checkbox" id="cond1">
-                  You have lost or will lose your employment or self-employment income for at least half of the 4-week period for which you are applying
+                <input type="checkbox" id="cond10">
+                  <span>You have lost or will lose your employment or self-employment income for at least half of the 4-week period for which you are applying</span>
               </label>
             </li>
             <li class="checkbox">
               <label>
                 <input type="checkbox"
-                      id="cond2">
-                  You are a resident of Canada
+                      id="cond11" role="checkbox">
+                  <span>You are a resident of Canada</span>
               </label>
             </li>
             <li class="checkbox">
               <label>
-                <input type="checkbox" id="cond3">
-                  You are 15 years of age or older when you apply
+                <input type="checkbox" id="cond12">
+                  <span>You are 15 years of age or older when you apply</span>
               </label>
             </li>
           </ul>
           <div role="checkbox"
               class="group_checkbox"
-              aria-checked="mixed"
+              aria-checked="false"
               aria-controls="cond1 cond2 cond3 cond4"
               tabindex="0">
               You are eligible and ready to proceed
           </div>
         </fieldset>
       </section>
-      <div id="def-preFooter"></div>
+      <section role="group" class="provisional mrgn-tp-lg">
+        <h2 class="wb-inv">Example 5</h2>
+        <fieldset class="chkbxrdio-grp">
+          <legend>
+            To qualify, you must meet <strong>all</strong> of the following <conditions:small class="text-muted">(checkboxes + implicite label, large box)</conditions:small>
+          </legend>
+          <ul class="form-group list-unstyled">
+            <li class="radio">
+              <label>
+                <input name="cond13" type="radio" id="cond13-a">
+                  <span>You have lost or will lose your employment or self-employment income for at least half of the 4-week period for which you are applying</span>
+              </label>
+            </li>
+            <li class="radio">
+              <label>
+                <input type="radio"
+                      name="cond13"
+                      id="cond13-b">
+                  <span>You are a resident of Canada</span>
+              </label>
+            </li>
+            <li class="radio">
+              <label>
+                <input type="radio" name="cond13" id="cond13-c">
+                  <span>You are 15 years of age or older when you apply</span>
+              </label>
+            </li>
+          </ul>
+          <div role="checkbox"
+              class="group_checkbox"
+              aria-checked="false"
+              aria-controls="cond1 cond2 cond3 cond4"
+              tabindex="0">
+              You are eligible and ready to proceed
+          </div>
+        </fieldset>
+      </section>      <div id="def-preFooter"></div>
       <!-- Write closure template -->
       <script>
         var defPreFooter = document.getElementById("def-preFooter");

--- a/working-on/checklist/checklist.html
+++ b/working-on/checklist/checklist.html
@@ -1,0 +1,139 @@
+<!DOCTYPE html>
+<html class="no-js" lang="en" dir="ltr">
+	<head>
+		<meta charset="utf-8">
+		<!-- Web Experience Toolkit (WET) / Boîte à outils de l'expérience Web (BOEW) wet-boew.github.io/wet-boew/License-en.html / wet-boew.github.io/wet-boew/Licence-fr.html -->
+		<title>Checklist, checboxes and radio button experimentations - Canada.ca</title>
+    <meta content="width=device-width,initial-scale=1" name="viewport">
+    <link rel="stylesheet" href="checklist.css">
+		<script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/v4_0_30/cdts/compiled/soyutils.js"></script>
+		<script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/v4_0_30/cdts/compiled/wet-en.js"></script>
+		<!-- Write closure template -->
+		<script>
+			document.write(wet.builder.refTop({
+			}));
+		</script>
+	</head>
+	<body vocab="http://schema.org/" typeof="WebPage">
+		<div id="def-top"></div>
+		<!-- Write closure template -->
+		<script>
+			var defTop = document.getElementById("def-top");
+			defTop.outerHTML = wet.builder.top({
+				lngLinks: [{
+					lang: "fr",
+					href: "cases-a-cocher.html",
+					text: "Français"
+				}],
+				breadcrumbs: [{
+					title: "Home",
+					href: "https://www.canada.ca/en.html"
+				},{
+					title: "Design system",
+					href: "https://www.canada.ca/en/government/about/design-system"
+				}, {
+          title: "Components",
+          href: "https://www.canada.ca/en/government/about/design-system/components"
+				}],
+				search: true,
+				siteMenu: true,
+				showPreContent: true
+			});
+    </script>
+    <main property="mainContentOfPage" class="container">    
+      <h1 property="name">Checklist examples</h1>
+      <section role="group" class="provisional">
+        <h2 class="wb-inv">Example 1</h2>
+        <p>To qualify, you must meet <strong>all</strong> of the following conditions:</p>
+        <ul class="wb-checklist wb-checklist-sm lst-none lst-spcd">
+          <li>
+            <div role="checkbox"
+                  aria-checked="false"
+                  tabindex="0"
+                  id="eligibility1">
+              You have lost or will lose your employment or self-employment income for at least half of the 4-week period for which you are applying
+            </div>
+          </li>
+          <li>
+            <div role="checkbox"
+                  aria-checked="false"
+                  tabindex="0"
+                  id="eligibility2">
+              You are a resident of Canada
+            </div>
+          </li>
+          <li>
+            <div role="checkbox"
+                  aria-checked="false"
+                  tabindex="0"
+                  id="eligibility3">
+              You are 15 years of age or older when you apply
+            </div>
+          </li>
+        </ul>
+        <p class="alert alert-success invisible" id="action-msg-all">You are eligible and ready to proceed</p>
+      </section>
+      <section role="group" class="provisional">
+        <h2 class="wb-inv">Example 2</h2>
+        <fieldset class="chkbxrdio-grp">
+          <legend>
+            To qualify, you must meet <strong>all</strong> of the following conditions:
+          </legend>
+          <ul class="form-group list-unstyled">
+            <li class="checkbox">
+              <label>
+                <input type="checkbox" id="cond1">
+                  You have lost or will lose your employment or self-employment income for at least half of the 4-week period for which you are applying
+              </label>
+            </li>
+            <li class="checkbox">
+              <label>
+                <input type="checkbox"
+                      id="cond2">
+                  You are a resident of Canada
+              </label>
+            </li>
+            <li class="checkbox">
+              <label>
+                <input type="checkbox" id="cond3">
+                  You are 15 years of age or older when you apply
+              </label>
+            </li>
+          </ul>
+          <div role="checkbox"
+              class="group_checkbox"
+              aria-checked="mixed"
+              aria-controls="cond1 cond2 cond3 cond4"
+              tabindex="0">
+              You are eligible and ready to proceed
+          </div>
+        </fieldset>
+      </section>
+      <div id="def-preFooter"></div>
+      <!-- Write closure template -->
+      <script>
+        var defPreFooter = document.getElementById("def-preFooter");
+        defPreFooter.outerHTML = wet.builder.preFooter({
+          dateModified: "2020-03-13",
+          showPostContent: true,
+          showFeedback: true,
+          showShare: true
+        });
+      </script>
+    </main>
+    <div id="def-footer"></div>
+    <!-- Write closure template -->
+    <script>
+      var defFooter = document.getElementById("def-footer");
+      defFooter.outerHTML = wet.builder.footer({
+        showFooter: true,
+        showFeatures: true
+      });
+    </script>
+    <!-- Write closure template -->
+    <script>
+      document.write(wet.builder.refFooter({
+      }));
+    </script>
+  </body>
+</html>

--- a/working-on/checklist/tmp/w3-checkbox.css
+++ b/working-on/checklist/tmp/w3-checkbox.css
@@ -1,0 +1,77 @@
+ul.checkboxes {
+  list-style: none;
+  margin-left: 0;
+  padding-left: 1em;
+}
+
+[role="checkbox"] {
+  display: inline-block;
+  position: relative;
+  padding-left: 1.4em;
+  cursor: default;
+}
+
+[role="checkbox"]::before,
+[role="checkbox"]::after {
+  position: absolute;
+  top: 50%;
+  left: 7px;
+  transform: translate(-50%, -50%);
+  content: '';
+}
+
+[role="checkbox"]::before {
+  width: 14px;
+  height: 14px;
+  border: 1px solid hsl(0, 0%, 66%);
+  border-radius: 0.2em;
+  background-image: linear-gradient(to bottom, hsl(300, 3%, 93%), #fff 30%);
+}
+
+[role="checkbox"]:active::before {
+  background-image: linear-gradient(to bottom, hsl(300, 3%, 73%), hsl(300, 3%, 93%) 30%);
+}
+
+[role="checkbox"][aria-checked="mixed"]::before,
+[role="checkbox"][aria-checked="true"]::before {
+  border-color: hsl(216, 80%, 50%);
+  background: hsl(217, 95%, 68%);
+  background-image: linear-gradient(to bottom, hsl(217, 95%, 68%), hsl(216, 80%, 57%));
+}
+
+[role="checkbox"][aria-checked="mixed"]::after {
+  display: block;
+  width: 8px;
+  border-bottom: 0.125em solid #fff;
+  transform: translate(-50%, -50%) rotateZ(45deg);
+  transform-origin: center center;
+}
+
+[role="checkbox"][aria-checked="mixed"]:active::after,
+[role="checkbox"][aria-checked="true"]::after {
+  display: block;
+  width: 0.25em;
+  height: 0.4em;
+  border: solid #fff;
+  border-width: 0 0.125em 0.125em 0;
+  transform: translateY(-65%) translateX(-50%) rotate(45deg);
+}
+
+[role="checkbox"][aria-checked="mixed"]:active::before,
+[role="checkbox"][aria-checked="true"]:active::before {
+  background-image: linear-gradient(to bottom, hsl(216, 80%, 57%), hsl(217, 95%, 68%));
+}
+
+[role="checkbox"]:focus {
+  outline: none;
+}
+
+[role="checkbox"]:focus::before {
+  width: 16px;
+  height: 16px;
+  box-sizing: content-box;
+  border-color: hsl(216, 94%, 73%);
+  border-width: 3px;
+  border-radius: calc(0.2em + 3px);
+  box-shadow: inset 0 0 0 1px hsl(216, 80%, 50%);
+}

--- a/working-on/checklist/tmp/w3-checkbox.js
+++ b/working-on/checklist/tmp/w3-checkbox.js
@@ -1,0 +1,84 @@
+/*
+*   This content is licensed according to the W3C Software License at
+*   https://www.w3.org/Consortium/Legal/2015/copyright-software-and-document
+*
+*   File:   Checkbox.js
+*
+*   Desc:   Checkbox widget that implements ARIA Authoring Practices
+*           for a menu of links
+*
+*/
+
+/*
+*   @constructor Checkbox
+*
+*
+*/
+var Checkbox = function (domNode) {
+
+  this.domNode = domNode;
+
+  this.keyCode = Object.freeze({
+    'RETURN': 13,
+    'SPACE': 32
+  });
+};
+
+Checkbox.prototype.init = function () {
+  this.domNode.tabIndex = 0;
+
+  if (!this.domNode.getAttribute('aria-checked')) {
+    this.domNode.setAttribute('aria-checked', 'false');
+  }
+
+  this.domNode.addEventListener('keydown',    this.handleKeydown.bind(this));
+  this.domNode.addEventListener('click',      this.handleClick.bind(this));
+  this.domNode.addEventListener('focus',      this.handleFocus.bind(this));
+  this.domNode.addEventListener('blur',       this.handleBlur.bind(this));
+
+};
+
+Checkbox.prototype.toggleCheckbox = function () {
+
+  if (this.domNode.getAttribute('aria-checked') === 'true') {
+    this.domNode.setAttribute('aria-checked', 'false');
+  }
+  else {
+    this.domNode.setAttribute('aria-checked', 'true');
+  }
+
+};
+
+/* EVENT HANDLERS */
+
+Checkbox.prototype.handleKeydown = function (event) {
+  var flag = false;
+
+  switch (event.keyCode) {
+    case this.keyCode.SPACE:
+      this.toggleCheckbox();
+      flag = true;
+      break;
+
+    default:
+      break;
+  }
+
+  if (flag) {
+    event.stopPropagation();
+    event.preventDefault();
+  }
+};
+
+Checkbox.prototype.handleClick = function (event) {
+  this.toggleCheckbox();
+};
+
+Checkbox.prototype.handleFocus = function (event) {
+  this.domNode.classList.add('focus');
+};
+
+Checkbox.prototype.handleBlur = function (event) {
+  this.domNode.classList.remove('focus');
+};
+

--- a/working-on/checklist/tmp/w3-checkboxMixed.js
+++ b/working-on/checklist/tmp/w3-checkboxMixed.js
@@ -1,0 +1,159 @@
+/*
+*   This content is licensed according to the W3C Software License at
+*   https://www.w3.org/Consortium/Legal/2015/copyright-software-and-document
+*
+*   File:   CheckboxMixed.js
+*
+*   Desc:   CheckboxMixed widget that implements ARIA Authoring Practices
+*           for a menu of links
+*/
+
+/*
+*   @constructor CheckboxMixed
+*
+*
+*/
+var CheckboxMixed = function (domNode) {
+
+  this.domNode = domNode;
+
+  this.controlledCheckboxes = [];
+
+  this.keyCode = Object.freeze({
+    'RETURN': 13,
+    'SPACE': 32
+  });
+};
+
+CheckboxMixed.prototype.init = function () {
+  this.domNode.tabIndex = 0;
+
+  var ids = this.domNode.getAttribute('aria-controls').split(' ');
+
+  for (var i = 0; i < ids.length; i++) {
+    var node = document.getElementById(ids[i]);
+    var ccb = new ControlledCheckbox(node, this);
+    ccb.init();
+    this.controlledCheckboxes.push(ccb);
+  }
+
+  this.domNode.addEventListener('keydown',    this.handleKeydown.bind(this));
+  this.domNode.addEventListener('click',      this.handleClick.bind(this));
+  this.domNode.addEventListener('focus',      this.handleFocus.bind(this));
+  this.domNode.addEventListener('blur',       this.handleBlur.bind(this));
+
+  this.updateCheckboxMixed();
+
+};
+
+CheckboxMixed.prototype.updateCheckboxMixed = function () {
+
+  var count = 0;
+
+  for (var i = 0; i < this.controlledCheckboxes.length; i++) {
+    if (this.controlledCheckboxes[i].isChecked()) {
+      count++;
+    }
+  }
+
+  if (count === 0) {
+    this.domNode.setAttribute('aria-checked', 'false');
+  }
+  else {
+    if (count === this.controlledCheckboxes.length) {
+      this.domNode.setAttribute('aria-checked', 'true');
+    }
+    else {
+      this.domNode.setAttribute('aria-checked', 'mixed');
+      this.updateControlledStates();
+    }
+  }
+};
+
+CheckboxMixed.prototype.updateControlledStates = function () {
+  for (var i = 0; i < this.controlledCheckboxes.length; i++) {
+    this.controlledCheckboxes[i].lastState = this.controlledCheckboxes[i].isChecked();
+  }
+};
+
+CheckboxMixed.prototype.anyLastChecked = function () {
+
+  var count = 0;
+
+  for (var i = 0; i < this.controlledCheckboxes.length; i++) {
+    if (this.controlledCheckboxes[i].lastState) {
+      count++;
+    }
+  }
+
+  return count > 0;
+
+};
+
+CheckboxMixed.prototype.setControlledCheckboxes = function (value) {
+
+  for (var i = 0; i < this.controlledCheckboxes.length; i++) {
+    this.controlledCheckboxes[i].setChecked(value);
+  }
+
+  this.updateCheckboxMixed();
+
+};
+
+CheckboxMixed.prototype.toggleCheckboxMixed = function () {
+
+  var state = this.domNode.getAttribute('aria-checked');
+
+  if (state === 'false') {
+    if (this.anyLastChecked()) {
+      this.setControlledCheckboxes('last');
+    }
+    else {
+      this.setControlledCheckboxes('true');
+    }
+  }
+  else {
+    if (state === 'mixed') {
+      this.setControlledCheckboxes('true');
+    }
+    else {
+      this.setControlledCheckboxes('false');
+    }
+  }
+
+  this.updateCheckboxMixed();
+};
+
+/* EVENT HANDLERS */
+
+CheckboxMixed.prototype.handleKeydown = function (event) {
+  var flag = false;
+
+  switch (event.keyCode) {
+    case this.keyCode.SPACE:
+      this.toggleCheckboxMixed();
+      flag = true;
+      break;
+
+    default:
+      break;
+  }
+
+  if (flag) {
+    event.stopPropagation();
+    event.preventDefault();
+  }
+};
+
+CheckboxMixed.prototype.handleClick = function (event) {
+  this.toggleCheckboxMixed();
+};
+
+CheckboxMixed.prototype.handleFocus = function (event) {
+  this.domNode.classList.add('focus');
+};
+
+CheckboxMixed.prototype.handleBlur = function (event) {
+  this.domNode.classList.remove('focus');
+};
+

--- a/working-on/checklist/tmp/w3-controlledCheckbox.js
+++ b/working-on/checklist/tmp/w3-controlledCheckbox.js
@@ -1,0 +1,106 @@
+/*
+*   This content is licensed according to the W3C Software License at
+*   https://www.w3.org/Consortium/Legal/2015/copyright-software-and-document
+*
+*   File:   controlledCheckbox.js
+*
+*   Desc:   ControlledCheckbox widget that implements ARIA Authoring Practices
+*           for a mixed checkbox
+*/
+
+/*
+*   @constructor ControlledCheckbox
+*
+*
+*/
+var ControlledCheckbox = function (domNode, controllerObj) {
+
+  this.domNode = domNode;
+  this.controller = controllerObj;
+  this.lastState = false;
+
+};
+
+ControlledCheckbox.prototype.init = function () {
+
+  this.lastState = this.isChecked();
+
+  console.log(this.lastState);
+
+  this.domNode.addEventListener('change', this.handleChange.bind(this));
+
+  this.domNode.addEventListener('keydown',    this.handleKeyup.bind(this), true);
+  this.domNode.addEventListener('click',      this.handleClick.bind(this), true);
+
+};
+
+ControlledCheckbox.prototype.isChecked = function () {
+  // if standard input[type=checkbox]
+  if (typeof this.domNode.checked === 'boolean') {
+    return this.domNode.checked;
+  }
+
+  // If ARIA checkbox widget
+  return this.domNode.getAttribute('aria-checked') === 'true';
+};
+
+ControlledCheckbox.prototype.setChecked = function (value) {
+  // if standard input[type=checkbox]
+  if (typeof this.domNode.checked === 'boolean') {
+
+    switch (value) {
+      case 'true':
+        this.domNode.checked = true;
+        break;
+
+      case 'false':
+        this.domNode.checked = false;
+        break;
+
+      case 'last':
+        this.domNode.checked = this.lastState;
+        break;
+
+      default:
+        break;
+    }
+  }
+
+  // If ARIA checkbox widget
+  if (typeof this.domNode.getAttribute('aria-checked') === 'string') {
+
+    switch (value) {
+      case 'true':
+      case 'false':
+        this.domNode.setAttribute('aria-checked', value);
+        break;
+
+      case 'last':
+        if (this.lastState) {
+          this.domNode.setAttribute('aria-checked', 'true');
+        }
+        else {
+          this.domNode.setAttribute('aria-checked', 'false');
+        }
+        break;
+
+      default:
+        break;
+    }
+  }
+};
+
+/* EVENT HANDLERS */
+
+ControlledCheckbox.prototype.handleChange = function (event) {
+  this.controller.updateCheckboxMixed();
+};
+
+ControlledCheckbox.prototype.handleKeyup = function (event) {
+  this.lastState = this.isChecked();
+};
+
+ControlledCheckbox.prototype.handleClick = function (event) {
+  this.lastState = this.isChecked();
+};
+

--- a/working-on/checklist/wb-checklist.js
+++ b/working-on/checklist/wb-checklist.js
@@ -1,0 +1,48 @@
+/**
+ * @title WET-BOEW Checklist plugin
+ * @overview Plugin contained to show an example of a custom WET checklist plugin
+ * @license wet-boew.github.io/wet-boew/License-en.html / wet-boew.github.io/wet-boew/Licence-fr.html
+ * @author @ux-tbs
+ */
+( function( $, window, wb ) {
+  "use strict";
+  /*
+   * Variable and function definitions.
+   * These are global to the plugin - meaning that they will be initialized once per page,
+   * not once per instance of plugin on the page. So, this is a good place to define
+   * variables that are common to all instances of the plugin on a page.
+   */
+  var componentName = "wb-checklist",
+    selector = "." + componentName,
+    initEvent = "wb-init" + selector,
+    $document = wb.doc,
+    /**
+     * @method init
+     * @param {jQuery Event} event Event that triggered the function call
+     */
+    init = function( event ) {
+      // Start initialization
+      // returns DOM object = proceed with init
+      // returns undefined = do not proceed with init (e.g., already initialized)
+      var elm = wb.init( event, componentName, selector ),
+        $elm;
+      if ( elm ) {
+        $elm = $( elm );
+        // ... Do the plugin initialisation
+        // Call my custom event
+        $elm.trigger( "name.of.your.event" );
+        // Identify that initialization has completed
+        wb.ready( $elm, componentName );
+      }
+    };
+  // Add your plugin event handler
+  $document.on( "name.of.your.event", selector, function( event ) {
+    var elm = event.currentTarget,
+      $elm = $( elm );
+    $elm.append( "Checklist" );
+  } );
+  // Bind the init event of the plugin
+  $document.on( "timerpoke.wb " + initEvent, selector, init );
+  // Add the timer poke to initialize the plugin
+  wb.add( selector );
+  } )( jQuery, window, wb );

--- a/working-on/checklist/wb-checklist.js
+++ b/working-on/checklist/wb-checklist.js
@@ -25,22 +25,64 @@
       // returns DOM object = proceed with init
       // returns undefined = do not proceed with init (e.g., already initialized)
       var elm = wb.init( event, componentName, selector ),
-        $elm;
+          $elm;
+
       if ( elm ) {
         $elm = $( elm );
-        // ... Do the plugin initialisation
-        // Call my custom event
-        $elm.trigger( "name.of.your.event" );
-        // Identify that initialization has completed
+        var $elms = $elm.find($("[role='checkbox']"));
+        for (let i = 0; i < $elms.length; i++) {
+          this.domNode = $elms.get(i);
+          this.keyCode = Object.freeze({
+            "RETURN": 13,
+            "SPACE": 32
+          })
+          this.domNode.tabIndex = 0;
+          if (!$(this.domNode).attr("aria-checked")) {
+            $(this.domNode).attr("aria-checked", "false");
+          }
+        }
+
+        $elm.trigger( "click" );
+        $elm.trigger( "keydown" );
+
         wb.ready( $elm, componentName );
       }
+    },
+    toggleCheckbox = function() {
+      if( $elm.attr("aria-checked") === "true" ) {
+        $elm.attr("aria-checked", "false");
+      } else {
+        $elm.attr("aria-checked", "true");
+      };
     };
   // Add your plugin event handler
-  $document.on( "name.of.your.event", selector, function( event ) {
-    var elm = event.currentTarget,
-      $elm = $( elm );
-    $elm.append( "Checklist" );
+  $document.on( "click", selector, function( event ) {
+    var elm = event.target,
+        $elm = $( elm );
+    if( $elm.attr("aria-checked") === "true" ) {
+      $elm.attr("aria-checked", "false");
+    } else {
+      $elm.attr("aria-checked", "true");
+    }
   } );
+
+  $document.on( "keydown", selector, function( event ) {
+    var flag = false;
+    switch (event.keyCode) {
+      case this.keyCode.SPACE:
+        this.toggleCheckbox();
+        flag = true;
+        break;
+
+      default:
+        break;
+    }
+
+    if (flag) {
+      event.stopPropagation();
+      event.preventDefault();
+    }
+  });
   // Bind the init event of the plugin
   $document.on( "timerpoke.wb " + initEvent, selector, init );
   // Add the timer poke to initialize the plugin


### PR DESCRIPTION
Checkbox
WAI-ARIA supports two types of checkbox widgets:

1. Dual-state: The most common type of checkbox, it allows the user to toggle between two choices -- checked and not checked.
2. Tri-state: This type of checkbox supports an additional third state known as partially checked.

One common use of a tri-state checkbox can be found in software installers where a single tri-state checkbox is used to represent and control the state of an entire group of install options. And, each option in the group can be individually turned on or off with a dual state checkbox.